### PR TITLE
Update sample_code_c7_1.py

### DIFF
--- a/section7/sample_code_c7_1.py
+++ b/section7/sample_code_c7_1.py
@@ -148,7 +148,7 @@ n_channels=np.shape(mic_alignments)[0]
 R=mic_alignments .T+mic_array_loc[:,None]
 
 # 部屋を生成する
-room = pa.ShoeBox(room_dim, fs=sample_rate)
+room = pa.ShoeBox(room_dim, fs=sample_rate, max_order=0)
 room_no_noise_left = pa.ShoeBox(room_dim, fs=sample_rate, max_order=0)
 room_no_noise_right = pa.ShoeBox(room_dim, fs=sample_rate, max_order=0)
 


### PR DESCRIPTION
素敵な書籍をありがとうございます。こちらの書籍を使って勉強しております。
複数マイクを用いた音源分離に関しては初心者なのですが、とてもわかりやすく順を追って綺麗に理解できます。

音声のスパース性に基づく音源分離（第７章第２節）のcode7.1について、修正のご提案です。
現状のsample_code_c7_1.pyでは、書籍と異なり次のような結果となります。
```
method:     PHASE AMPLITUDE
Δsnr [dB]: 8.34 3.98
```
これはShoeBoxのインスタンス化（L151）において、`max_order`を指定しておらずデフォルトの`max_order=1`が適用されてしまうのが原因のようです。

修正後は書籍通り、
```
method:     PHASE AMPLITUDE
Δsnr [dB]: 10.88 6.16
```
の結果を得ることができました。

些細なことで恐縮ですが、よろしくお願いいたします。